### PR TITLE
ci: fix GitHub Actions workflow to push Docker images to GHCR

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ${{ env.REGISTRY }}/${{ github.repository }}
 
 jobs:
   build-and-push:


### PR DESCRIPTION
Align Docker registry login and image tagging to use GitHub Container Registry (ghcr.io) to fix unauthorized error during image push. This ensures proper authentication and successful push to GHCR.